### PR TITLE
Revert bypass of authentication on SignIn page

### DIFF
--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -23,5 +23,7 @@
             </intent-filter>
         </activity>
     </application>
-
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 </manifest>

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/AuthSignIn.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/AuthSignIn.java
@@ -75,15 +75,15 @@ public class AuthSignIn extends Fragment {
         signInButton.setOnClickListener((btnView) -> {
             SignInDetails details = validateFields();
             if (details != null) {
-                // Log.i("Signin", "Trying to login as " + details.email);
+                 Log.i("Signin", "Trying to login as " + details.email);
                 auth.signInWithEmailAndPassword(details.email, details.password)
                         .addOnSuccessListener(result -> {
                             Log.i("Login", "Logged in as user with id: " + result.getUser().getUid());
                             Navigation.findNavController(btnView).navigate(R.id.action_authSignIn_to_homeFeed);
                         })
-                        // .addOnFailureListener(error -> {
-                        //     Log.e("Signin", error.toString());
-                        // })
+                         .addOnFailureListener(error -> {
+                             Log.e("Signin", error.toString());
+                         })
                         ;
             }
         });

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/AuthSignIn.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/AuthSignIn.java
@@ -72,21 +72,21 @@ public class AuthSignIn extends Fragment {
         topAppBar.setNavigationOnClickListener(
                 Navigation.createNavigateOnClickListener(R.id.action_authSignIn_to_authHome));
 
-//        TODO: these 3 lines are for testing unconditionally jumping to home_feed without any authentication
-        signInButton.setOnClickListener(btnView -> {
-            Navigation.findNavController(btnView).navigate(R.id.action_authSignIn_to_homeFeed);
+        signInButton.setOnClickListener((btnView) -> {
+            SignInDetails details = validateFields();
+            if (details != null) {
+                // Log.i("Signin", "Trying to login as " + details.email);
+                auth.signInWithEmailAndPassword(details.email, details.password)
+                        .addOnSuccessListener(result -> {
+                            Log.i("Login", "Logged in as user with id: " + result.getUser().getUid());
+                            Navigation.findNavController(btnView).navigate(R.id.action_authSignIn_to_homeFeed);
+                        })
+                        // .addOnFailureListener(error -> {
+                        //     Log.e("Signin", error.toString());
+                        // })
+                        ;
+            }
         });
-
-//        signInButton.setOnClickListener((btnView) -> {
-//            SignInDetails details = validateFields();
-//            if (details != null) {
-//                auth.signInWithEmailAndPassword(details.email, details.password)
-//                        .addOnSuccessListener(result -> {
-//                            Log.i("Login", "Logged in as user with id: " + result.getUser().getUid());
-//                            Navigation.findNavController(btnView).navigate(R.id.action_authSignIn_to_homeFeed);
-//                        });
-//            }
-//        });
 
         return view;
     }


### PR DESCRIPTION
Resolves: Fixes the previous bypass of authentication on SignIn page to HomeFeed page #165

**Description**

What did you change?
 - This fix does use firebase authentication now

How should a reviewer test?
 - Try Logging in with some valid credentials on SIgn In Page

**Reviewer Checklist**

- [x] Are all relevant issues referenced by this PR?
- [x] Does the app still build?
- [ ] Do all tests pass? (TODO: Automate this with GitHub actions)
- [x] Does the feature work as expected?
- [x] Does the feature still keep the app bug free?
- [x] Is the description of the changes correct/present?
