### PR TITLE
Another user details page

### DIFF
--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/MoodDetailsNavigationTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/MoodDetailsNavigationTest.java
@@ -165,43 +165,6 @@ public class MoodDetailsNavigationTest extends FirebaseEmulatorMixin {
                 .check(matches(withText(DATA_REASON)));
     }
 
-    @Test
-    public void testViewProfileNavigationFromMoodDetails() throws InterruptedException, ExecutionException {
-        seedDatabase();
-
-        // Sign in
-        onView(withText("Sign In")).perform(click());
-        onView(withId(R.id.emailSignIn))
-                .perform(replaceText(USER_EMAIL), closeSoftKeyboard());
-        onView(withId(R.id.passwordSignIn))
-                .perform(replaceText(USER_PASSWORD), closeSoftKeyboard());
-        onView(withId(R.id.signInButtonAuthToHome))
-                .perform(click());
-
-        // Wait for HomeFeed to load data
-        SystemClock.sleep(3000);
-
-        // Click on the first mood item's "View Details" button.
-        onView(withId(R.id.moodRecyclerView))
-                .perform(actionOnItemAtPosition(0, clickChildViewWithId(R.id.viewDetailsButton)));
-
-        // Wait for the MoodDetails screen to load.
-        SystemClock.sleep(3000);
-
-        // Scroll the NestedScrollView to the bottom using a custom action.
-        onView(withId(R.id.nestedScrollView))
-                .perform(scrollNestedScrollViewToBottom());
-
-        // Now click the "View Profile" button.
-        onView(withId(R.id.btnViewProfile))
-                .perform(click());
-
-        // Wait for the MyProfile screen to load.
-        SystemClock.sleep(3000);
-
-        // Verify that the MyProfile screen is displayed (e.g., check that the sign-out button is visible).
-        onView(withId(R.id.signOutButton)).check(matches(isDisplayed()));
-    }
 
     // Custom ViewAction to scroll a NestedScrollView to the bottom.
     public static ViewAction scrollNestedScrollViewToBottom() {

--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/OtherProfilePageNavigationTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/OtherProfilePageNavigationTest.java
@@ -123,6 +123,8 @@ public class OtherProfilePageNavigationTest extends FirebaseEmulatorMixin {
     @Test
     public void testViewOtherProfilePageNavigationFromMoodDetails() throws InterruptedException, ExecutionException {
         onView(withText("Sign In")).perform(click());
+        SystemClock.sleep(3000);
+
         onView(withId(R.id.emailSignIn))
                 .perform(replaceText(USER_EMAIL), closeSoftKeyboard());
         onView(withId(R.id.passwordSignIn))

--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/OtherProfilePageNavigationTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/OtherProfilePageNavigationTest.java
@@ -1,0 +1,142 @@
+package com.kernelcrew.moodapp;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+import static com.kernelcrew.moodapp.MoodDetailsNavigationTest.clickChildViewWithId;
+import static com.kernelcrew.moodapp.MoodDetailsNavigationTest.scrollNestedScrollViewToBottom;
+
+import android.os.SystemClock;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.kernelcrew.moodapp.data.Emotion;
+import com.kernelcrew.moodapp.data.MoodEvent;
+import com.kernelcrew.moodapp.data.MoodEventProvider;
+import com.kernelcrew.moodapp.ui.MainActivity;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+
+@RunWith(AndroidJUnit4.class)
+public class OtherProfilePageNavigationTest extends FirebaseEmulatorMixin {
+    private static final String USER_EMAIL = "test@kernelcrew.com";
+    private static final String USER_PASSWORD = "Password@1234";
+    private static final String EXPECTED_USERNAME = "testUser";
+    private static final Emotion DATA_EMOTION = Emotion.HAPPINESS;
+    private static final String DATA_TRIGGER = "Morning Coffee";
+    private static final String DATA_SOCIALSITUATION = "With Friends";
+    private static final String DATA_REASON = "Celebration";
+    private static final String DATA_PHOTOURL = "https://example.com/photo.jpg";
+    private static final double DATA_LATITUDE = 34.052235;
+    private static final double DATA_LONGITUDE = -118.243683;
+
+    @Rule
+    public ActivityScenarioRule<MainActivity> activityScenarioRule =
+            new ActivityScenarioRule<>(MainActivity.class);
+
+    @BeforeClass
+    public static void seedDatabase() throws ExecutionException, InterruptedException {
+        FirebaseAuth auth = FirebaseAuth.getInstance();
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+
+        // Create (or ensure) the test user exists.
+        try {
+            Tasks.await(auth.createUserWithEmailAndPassword(USER_EMAIL, USER_PASSWORD));
+        } catch (ExecutionException e) {
+            if (!(e.getCause() instanceof com.google.firebase.auth.FirebaseAuthUserCollisionException)) {
+                throw e;
+            }
+        }
+
+        // Sign in so Firestore security rules allow write operations.
+        Tasks.await(auth.signInWithEmailAndPassword(USER_EMAIL, USER_PASSWORD));
+
+        // Get the current user's UID.
+        String uid = Objects.requireNonNull(auth.getCurrentUser()).getUid();
+
+        // Seed a user document in the "users" collection.
+        Map<String, Object> userData = new HashMap<>();
+        userData.put("uid", uid);
+        userData.put("email", USER_EMAIL);
+        userData.put("username", EXPECTED_USERNAME);
+        Tasks.await(db.collection("users").document(uid).set(userData));
+
+        // Seed a MoodEvent document.
+        MoodEvent testEvent = new MoodEvent(
+                uid,
+                DATA_EMOTION,
+                DATA_TRIGGER,         // trigger
+                DATA_SOCIALSITUATION,   // socialSituation
+                DATA_REASON,          // reason
+                DATA_PHOTOURL,        // photoUrl
+                DATA_LATITUDE,        // latitude
+                DATA_LONGITUDE        // longitude
+        );
+        Tasks.await(MoodEventProvider.getInstance().insertMoodEvent(testEvent));
+
+        auth.signOut();
+    }
+
+    @Before
+    public void setupAuth() throws InterruptedException, ExecutionException {
+        loginUser();
+    }
+
+    @Test
+    public void testViewOtherProfilePageNavigationFromMoodDetails() throws InterruptedException, ExecutionException {
+        seedDatabase();
+
+        // Sign in
+        onView(withText("Sign In")).perform(click());
+        onView(withId(R.id.emailSignIn))
+                .perform(replaceText(USER_EMAIL), closeSoftKeyboard());
+        onView(withId(R.id.passwordSignIn))
+                .perform(replaceText(USER_PASSWORD), closeSoftKeyboard());
+        onView(withId(R.id.signInButtonAuthToHome))
+                .perform(click());
+
+        // Wait for HomeFeed to load data
+        SystemClock.sleep(1000);
+
+        onView(withId(R.id.moodRecyclerView))
+                .perform(actionOnItemAtPosition(0, clickChildViewWithId(R.id.viewDetailsButton)));
+
+        // Wait for the MoodDetails screen to load
+        SystemClock.sleep(1000);
+
+        // Scroll the NestedScrollView to the bottom
+        onView(withId(R.id.nestedScrollView))
+                .perform(scrollNestedScrollViewToBottom());
+
+        onView(withId(R.id.btnViewProfile))
+                .perform(click());
+
+        // Wait for the OtherUserProfile screen to load
+        SystemClock.sleep(1000);
+
+        // Verify that the OtherUserProfile screen displays the expected username and email.
+        onView(withId(R.id.username_text)).check(matches(withText(EXPECTED_USERNAME)));
+        onView(withId(R.id.email_text)).check(matches(withText(USER_EMAIL)));
+    }
+
+    @After
+    public void signOutTheUser() {
+        FirebaseAuth.getInstance().signOut();
+    }
+}

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodDetails.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodDetails.java
@@ -87,7 +87,7 @@ public class MoodDetails extends Fragment implements DeleteDialogFragment.Delete
             if (userId != null && !userId.isEmpty()) {
                 Bundle args = new Bundle();
                 args.putString("uid", userId);
-                // Navigate to OtherUserProfile; ensure your nav_graph.xml has a destination with this ID.
+                // Ensure your nav_graph.xml includes a destination for OtherUserProfile with the ID otherUserProfile
                 NavHostFragment.findNavController(this)
                         .navigate(R.id.otherUserProfile, args);
             } else {

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodDetails.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodDetails.java
@@ -87,8 +87,9 @@ public class MoodDetails extends Fragment implements DeleteDialogFragment.Delete
             if (userId != null && !userId.isEmpty()) {
                 Bundle args = new Bundle();
                 args.putString("uid", userId);
+                // Navigate to OtherUserProfile; ensure your nav_graph.xml has a destination with this ID.
                 NavHostFragment.findNavController(this)
-                        .navigate(R.id.myProfile, args);
+                        .navigate(R.id.otherUserProfile, args);
             } else {
                 Toast.makeText(requireContext(), "User information unavailable.", Toast.LENGTH_SHORT).show();
             }

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/OtherUserProfile.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/OtherUserProfile.java
@@ -1,20 +1,23 @@
 package com.kernelcrew.moodapp.ui;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.fragment.NavHostFragment;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.kernelcrew.moodapp.R;
 import com.kernelcrew.moodapp.data.UserProvider;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
 
 public class OtherUserProfile extends Fragment {
 
+    private static final String TAG = "OtherUserProfile";
     private String uidToLoad;
     private TextView usernameText;
     private TextView emailText;
@@ -23,38 +26,55 @@ public class OtherUserProfile extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        // Inflate our layout for the fragment
         View view = inflater.inflate(R.layout.fragment_other_user_profile, container, false);
+        FirebaseUser currentUser = FirebaseAuth.getInstance().getCurrentUser();
+        if (currentUser == null) {
+            Log.e("OtherUserProfile", "User is not authenticated!");
+        } else {
+            Log.d("OtherUserProfile", "User authenticated: " + currentUser.getUid());
+        }
 
         toolbar = view.findViewById(R.id.topAppBarOther);
         usernameText = view.findViewById(R.id.username_text);
         emailText = view.findViewById(R.id.email_text);
 
-        // Set up the back button in the app bar to return to Mood Details
-        toolbar.setNavigationIcon(R.drawable.ic_back); // Ensure you have a back icon resource
+        // Setup back button to return to Mood Details
+        toolbar.setNavigationIcon(R.drawable.ic_back);
         toolbar.setNavigationOnClickListener(v -> NavHostFragment.findNavController(this).popBackStack());
 
-        // Retrieve the UID passed from MoodDetails
+        // Retrieve the UID from the navigation arguments
         if (getArguments() != null) {
             uidToLoad = getArguments().getString("uid");
+            Log.d(TAG, "UID to load: " + uidToLoad);
         }
 
-        // Load the user details from Firebase using UserProvider
         if (uidToLoad != null) {
-            UserProvider userProvider = UserProvider.getInstance();
-            userProvider.addSnapshotListenerForUser(uidToLoad, (documentSnapshot, error) -> {
+            UserProvider.getInstance().addSnapshotListenerForUser(uidToLoad, (documentSnapshot, error) -> {
                 if (error != null) {
-                    usernameText.setText("Error loading User");
+                    Log.e(TAG, "Error loading user: ", error);
+                    usernameText.setText("Error loading user");
                     emailText.setText("");
                     return;
                 }
                 if (documentSnapshot != null && documentSnapshot.exists()) {
+                    Log.d(TAG, "User document data: " + documentSnapshot.getData());
                     String username = documentSnapshot.getString("username");
-                    String email = documentSnapshot.getString("email");
+                    if (username == null) {
+                        username = documentSnapshot.getString("name");
+                    }
                     usernameText.setText(username != null ? username : "Unknown User");
+
+                    // Get email from Firestore
+                    String email = documentSnapshot.getString("email");
                     emailText.setText(email != null ? email : "No Email Provided");
+                } else {
+                    usernameText.setText("User not found");
+                    emailText.setText("");
                 }
             });
+        } else {
+            usernameText.setText("No user ID provided");
+            emailText.setText("");
         }
 
         return view;

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/OtherUserProfile.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/OtherUserProfile.java
@@ -1,0 +1,53 @@
+package com.kernelcrew.moodapp.ui;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import com.kernelcrew.moodapp.R;
+import com.kernelcrew.moodapp.data.UserProvider;
+
+public class OtherUserProfile extends Fragment {
+
+    private String uidToLoad;
+    private TextView usernameText;
+    private ImageView profileImage;
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment (create the file below)
+        View view = inflater.inflate(R.layout.fragment_other_user_profile, container, false);
+
+        usernameText = view.findViewById(R.id.username_text);
+        profileImage = view.findViewById(R.id.profile_image);
+
+        // Retrieve UID from arguments passed via navigation
+        if (getArguments() != null) {
+            uidToLoad = getArguments().getString("uid");
+        }
+
+        // Load the other user's details from Firestore using your UserProvider
+        if (uidToLoad != null) {
+            UserProvider userProvider = UserProvider.getInstance();
+            userProvider.addSnapshotListenerForUser(uidToLoad, (documentSnapshot, error) -> {
+                if (error != null) {
+                    usernameText.setText("Error loading user");
+                    return;
+                }
+                if (documentSnapshot != null && documentSnapshot.exists()) {
+                    String username = documentSnapshot.getString("username");
+                    usernameText.setText(username != null ? username : "Unknown User");
+                    // Optionally, load and set the user's profile image here.
+                }
+            });
+        }
+
+        return view;
+    }
+}

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/OtherUserProfile.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/OtherUserProfile.java
@@ -4,11 +4,12 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.navigation.fragment.NavHostFragment;
+import com.google.android.material.appbar.MaterialToolbar;
 import com.kernelcrew.moodapp.R;
 import com.kernelcrew.moodapp.data.UserProvider;
 
@@ -16,34 +17,42 @@ public class OtherUserProfile extends Fragment {
 
     private String uidToLoad;
     private TextView usernameText;
-    private ImageView profileImage;
+    private TextView emailText;
+    private MaterialToolbar toolbar;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        // Inflate the layout for this fragment (create the file below)
+        // Inflate our layout for the fragment
         View view = inflater.inflate(R.layout.fragment_other_user_profile, container, false);
 
+        toolbar = view.findViewById(R.id.topAppBarOther);
         usernameText = view.findViewById(R.id.username_text);
-        profileImage = view.findViewById(R.id.profile_image);
+        emailText = view.findViewById(R.id.email_text);
 
-        // Retrieve UID from arguments passed via navigation
+        // Set up the back button in the app bar to return to Mood Details
+        toolbar.setNavigationIcon(R.drawable.ic_back); // Ensure you have a back icon resource
+        toolbar.setNavigationOnClickListener(v -> NavHostFragment.findNavController(this).popBackStack());
+
+        // Retrieve the UID passed from MoodDetails
         if (getArguments() != null) {
             uidToLoad = getArguments().getString("uid");
         }
 
-        // Load the other user's details from Firestore using your UserProvider
+        // Load the user details from Firebase using UserProvider
         if (uidToLoad != null) {
             UserProvider userProvider = UserProvider.getInstance();
             userProvider.addSnapshotListenerForUser(uidToLoad, (documentSnapshot, error) -> {
                 if (error != null) {
-                    usernameText.setText("Error loading user");
+                    usernameText.setText("Error loading User");
+                    emailText.setText("");
                     return;
                 }
                 if (documentSnapshot != null && documentSnapshot.exists()) {
                     String username = documentSnapshot.getString("username");
+                    String email = documentSnapshot.getString("email");
                     usernameText.setText(username != null ? username : "Unknown User");
-                    // Optionally, load and set the user's profile image here.
+                    emailText.setText(email != null ? email : "No Email Provided");
                 }
             });
         }

--- a/code/app/src/main/res/layout/fragment_other_user_profile.xml
+++ b/code/app/src/main/res/layout/fragment_other_user_profile.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <!-- App bar -->
+    <!-- App Bar with Back Button -->
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayoutOther"
         android:layout_width="match_parent"
@@ -20,7 +20,7 @@
             app:titleCentered="true" />
     </com.google.android.material.appbar.AppBarLayout>
 
-    <!-- Content Card -->
+    <!-- User Details Card -->
     <androidx.cardview.widget.CardView
         android:id="@+id/otherProfileCard"
         android:layout_width="0dp"
@@ -36,24 +36,25 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="16dp"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
+            android:orientation="vertical">
 
-            <ImageView
-                android:id="@+id/profile_image"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:scaleType="centerCrop"
-                android:src="@drawable/ic_person" />
-
+            <!-- Username -->
             <TextView
                 android:id="@+id/username_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
                 android:text="Username"
                 android:textSize="18sp"
                 android:textStyle="bold" />
+
+            <!-- Email -->
+            <TextView
+                android:id="@+id/email_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Email"
+                android:textSize="16sp"
+                android:layout_marginTop="8dp" />
         </LinearLayout>
     </androidx.cardview.widget.CardView>
 

--- a/code/app/src/main/res/layout/fragment_other_user_profile.xml
+++ b/code/app/src/main/res/layout/fragment_other_user_profile.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- App bar -->
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayoutOther"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/topAppBarOther"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:title="Other User Profile"
+            app:titleCentered="true" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <!-- Content Card -->
+    <androidx.cardview.widget.CardView
+        android:id="@+id/otherProfileCard"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="4dp"
+        app:layout_constraintTop_toBottomOf="@id/appBarLayoutOther"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="16dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/profile_image"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:scaleType="centerCrop"
+                android:src="@drawable/ic_person" />
+
+            <TextView
+                android:id="@+id/username_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="Username"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/code/app/src/main/res/navigation/nav_graph.xml
+++ b/code/app/src/main/res/navigation/nav_graph.xml
@@ -163,4 +163,13 @@
     <action
         android:id="@+id/action_followingFragment_to_requestFragment"
         app:destination="@id/requestFragment" />
+    <fragment
+        android:id="@+id/otherUserProfile"
+        android:name="com.kernelcrew.moodapp.ui.OtherUserProfile"
+        android:label="Other User Profile" >
+        <!-- Define any arguments if needed -->
+        <argument
+            android:name="uid"
+            app:argType="string" />
+    </fragment>
 </navigation>

--- a/code/app/src/main/res/navigation/nav_graph.xml
+++ b/code/app/src/main/res/navigation/nav_graph.xml
@@ -167,7 +167,6 @@
         android:id="@+id/otherUserProfile"
         android:name="com.kernelcrew.moodapp.ui.OtherUserProfile"
         android:label="Other User Profile" >
-        <!-- Define any arguments if needed -->
         <argument
             android:name="uid"
             app:argType="string" />

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,6 +5,9 @@ service cloud.firestore {
     // can create user if and only if they have a valid user (which involves having a valid username)
     match /users/{userId} {
         allow create: if request.auth.uid == userId && isUniqueUsernameAndOwner(request.resource.data.username);
+      	allow read: if request.auth != null;
+        allow update: if request.auth.uid == userId;
+        allow write: if request.auth != null && request.auth.uid == userId;
     }
 
     // makes sure that only unique usernames can be added to usernames


### PR DESCRIPTION
## Summary

 - Implemented the "other user profile page" to access username, email of the other user
 - This page can be accessed by clicking "view details" on any mood from mood feed
     - then scroll down to the bottom of the page, and click the "view profile" button,
     - and just verify if the credentials displayed match the credentials of the mood owner of that mood or not

Resolves: #210  
Resolves: #211 

## Testing

- How should a reviewer test this feature, fix, or UI?
     - Run the "OtherProfilePageNavigationTest.java" test
- Are there any specific commands, steps, or credentials needed?
     - N/A

## Merge Instructions

- Any considerations that other PR's may need to take into note? 
     - N/A
- Should the reviewer delete the branch on merge?
     - Yes Please!

---

**Reviewer's Checklist**
- [x] Are all relevant issues referenced by this PR?
- [x] Does the app still build (locally)?
- [x] Do all tests pass?
- [x] Does the feature work as expected?
- [x] Does this feature preserve the app’s existing stability?  
- [x] Is the description of the changes correct/present?
- [x] Have new tests been created or existing tests updated as needed?
