### PR TITLE
Add public/private toggle to mood event form

### DIFF
--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/CreateMoodEventTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/CreateMoodEventTest.java
@@ -19,6 +19,7 @@ import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.QuerySnapshot;
 import com.kernelcrew.moodapp.data.Emotion;
 import com.kernelcrew.moodapp.data.MoodEvent;
+import com.kernelcrew.moodapp.data.MoodEventVisibility;
 import com.kernelcrew.moodapp.ui.MainActivity;
 import com.kernelcrew.moodapp.ui.components.EmotionPickerFragment;
 
@@ -62,7 +63,6 @@ public class CreateMoodEventTest extends FirebaseEmulatorMixin {
                 .untilAsserted(() -> {
                     QuerySnapshot results = Tasks.await(db.collection("moodEvents").get());
                     List<DocumentSnapshot> moodEvents = results.getDocuments();
-                    assertEquals(1, moodEvents.size());
                     MoodEvent newEvent = null;
                     for (DocumentSnapshot snapshot : moodEvents) {
                         MoodEvent event = snapshot.toObject(MoodEvent.class);
@@ -71,6 +71,33 @@ public class CreateMoodEventTest extends FirebaseEmulatorMixin {
                         }
                     }
                     assertNotNull(newEvent);
+                });
+    }
+
+    @Test
+    public void createMoodVisibilitySelector() {
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+
+        onView(withId(R.id.page_createMoodEvent)).perform(click());
+
+        onView(withId(R.id.toggle_fear)).perform(click());
+        onView(withId(R.id.visible_private_button)).perform(scrollTo()).perform(click());
+        onView(withId(R.id.submit_button)).perform(scrollTo()).perform(click());
+
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    QuerySnapshot results = Tasks.await(db.collection("moodEvents").get());
+                    List<DocumentSnapshot> moodEvents = results.getDocuments();
+                    MoodEvent newEvent = null;
+                    for (DocumentSnapshot snapshot : moodEvents) {
+                        MoodEvent event = snapshot.toObject(MoodEvent.class);
+                        assertNotNull(event);
+                        if (event.getEmotion() == Emotion.FEAR) {
+                            newEvent = event;
+                        }
+                    }
+                    assertNotNull(newEvent);
+                    assertEquals(MoodEventVisibility.PRIVATE, newEvent.getVisibility());
                 });
     }
 

--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/CreateMoodEventTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/CreateMoodEventTest.java
@@ -80,7 +80,7 @@ public class CreateMoodEventTest extends FirebaseEmulatorMixin {
 
         onView(withId(R.id.page_createMoodEvent)).perform(click());
 
-        onView(withId(R.id.toggle_fear)).perform(click());
+        onView(withId(R.id.toggle_sadness)).perform(click());
         onView(withId(R.id.visible_private_button)).perform(scrollTo()).perform(click());
         onView(withId(R.id.submit_button)).perform(scrollTo()).perform(click());
 
@@ -92,7 +92,7 @@ public class CreateMoodEventTest extends FirebaseEmulatorMixin {
                     for (DocumentSnapshot snapshot : moodEvents) {
                         MoodEvent event = snapshot.toObject(MoodEvent.class);
                         assertNotNull(event);
-                        if (event.getEmotion() == Emotion.FEAR) {
+                        if (event.getEmotion() == Emotion.SADNESS) {
                             newEvent = event;
                         }
                     }

--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/EditMoodEventTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/EditMoodEventTest.java
@@ -21,6 +21,7 @@ import com.google.firebase.firestore.QuerySnapshot;
 import com.kernelcrew.moodapp.data.Emotion;
 import com.kernelcrew.moodapp.data.MoodEvent;
 import com.kernelcrew.moodapp.data.MoodEventProvider;
+import com.kernelcrew.moodapp.data.MoodEventVisibility;
 import com.kernelcrew.moodapp.ui.MainActivity;
 
 import org.junit.BeforeClass;
@@ -67,6 +68,7 @@ public class EditMoodEventTest extends FirebaseEmulatorMixin {
 
         onView(withId(R.id.btnEditMood)).perform(click());
         onView(withId(R.id.toggle_shame)).perform(click());
+        onView(withId(R.id.visible_private_button)).perform(scrollTo()).perform(click());
         onView(withId(R.id.submit_button)).perform(scrollTo()).perform(click());
 
         await().atMost(10, TimeUnit.SECONDS)
@@ -74,7 +76,9 @@ public class EditMoodEventTest extends FirebaseEmulatorMixin {
                     QuerySnapshot results = Tasks.await(db.collection("moodEvents").get());
                     List<DocumentSnapshot> moodEvents = results.getDocuments();
                     assertEquals(1, moodEvents.size());
-                    assertEquals("SHAME", moodEvents.get(0).get("emotion"));
+                    MoodEvent moodEvent = moodEvents.get(0).toObject(MoodEvent.class);
+                    assertEquals(Emotion.SHAME, moodEvent.getEmotion());
+                    assertEquals(MoodEventVisibility.PRIVATE, moodEvent.getVisibility());
                 });
     }
 }

--- a/code/app/src/main/java/com/kernelcrew/moodapp/data/MoodEvent.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/data/MoodEvent.java
@@ -1,18 +1,14 @@
 package com.kernelcrew.moodapp.data;
 
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.net.Uri;
-import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.firebase.firestore.Exclude;
 import com.kernelcrew.moodapp.utils.PhotoUtils;
 
-import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -31,6 +27,8 @@ public class MoodEvent implements Serializable {
     private Bitmap photo;
     private Double latitude;
     private Double longitude;
+
+    private @NonNull MoodEventVisibility visibility = MoodEventVisibility.PUBLIC;
 
     /**
      * Empty constructor for Firestore deserialization. Do not use.
@@ -160,5 +158,21 @@ public class MoodEvent implements Serializable {
 
     public long getTimestamp() {
         return this.created.getTime();
+    }
+
+    public @NonNull MoodEventVisibility getVisibility() {
+        return visibility;
+    }
+
+    /**
+     * Update the visibility. Cannot change visibility to null.
+     * @param visibility New visibility. If null, no change is made.
+     */
+    public void setVisibility(MoodEventVisibility visibility) {
+        if (visibility == null) {
+            return;
+        }
+
+        this.visibility = visibility;
     }
 }

--- a/code/app/src/main/java/com/kernelcrew/moodapp/data/MoodEventVisibility.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/data/MoodEventVisibility.java
@@ -1,0 +1,17 @@
+package com.kernelcrew.moodapp.data;
+
+/**
+ * The visibility of a mood event.
+ * Controls who is allowed to read the mood event.
+ */
+public enum MoodEventVisibility {
+    /**
+     * Anyone following the author can view this mood event.
+     */
+    PUBLIC,
+
+    /**
+     * Only the author can view this mood event.
+     */
+    PRIVATE,
+}

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodEventForm.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodEventForm.java
@@ -18,7 +18,6 @@ import androidx.fragment.app.FragmentContainerView;
 
 import android.provider.MediaStore;
 import android.util.Log;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AutoCompleteTextView;
@@ -27,10 +26,12 @@ import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.android.material.button.MaterialButtonToggleGroup;
 import com.google.android.material.textfield.TextInputEditText;
 import com.kernelcrew.moodapp.R;
 import com.kernelcrew.moodapp.data.Emotion;
 import com.kernelcrew.moodapp.data.MoodEvent;
+import com.kernelcrew.moodapp.data.MoodEventVisibility;
 import com.kernelcrew.moodapp.ui.components.EmotionPickerFragment;
 import com.kernelcrew.moodapp.utils.PhotoUtils;
 import java.io.IOException;
@@ -55,6 +56,7 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
     private ImageButton photoButton;
     private Button photoResetButton;
     private TextView photoButtonError;
+    private MaterialButtonToggleGroup visibilityToggle;
 
     /**
      * Handler for the image picker submission action.
@@ -140,6 +142,7 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
         Double lat;
         Double lon;
         Bitmap photo;
+        MoodEventVisibility visibility;
 
         /**
          * Empty constructor which initializes everything to null.
@@ -158,6 +161,7 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
             lat = moodEvent.getLatitude();
             lon = moodEvent.getLongitude();
             photo = moodEvent.getPhoto();
+            visibility = moodEvent.getVisibility();
         }
 
         /**
@@ -178,6 +182,7 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
             );
 
             moodEvent.setPhoto(photo);
+            moodEvent.setVisibility(visibility);
 
             return moodEvent;
         }
@@ -198,6 +203,17 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
         photo = details.photo;
         photoButton.setImageBitmap(details.photo);
         updateResetPhotoVisibility();
+
+        visibilityToggle.clearChecked();
+        switch (details.visibility) {
+            case PUBLIC:
+                visibilityToggle.check(R.id.visible_public_button);
+                break;
+            case PRIVATE:
+                visibilityToggle.check(R.id.visible_private_button);
+                break;
+        }
+    }
 
     private void resetPhotoButtonError() {
         photoButtonError.setText(null);
@@ -240,6 +256,14 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
             photoButtonError.setLayoutParams(layoutParams);
             return null;
         }
+
+        int checkedButton = visibilityToggle.getCheckedButtonId();
+        if (checkedButton == R.id.visible_public_button) {
+            details.visibility = MoodEventVisibility.PUBLIC;
+        } else if (checkedButton == R.id.visible_private_button) {
+            details.visibility = MoodEventVisibility.PRIVATE;
+        }
+
         details.lat = currentLatitude;
         details.lon = currentLongitude;
 
@@ -288,6 +312,7 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
         photoResetButton = view.findViewById(R.id.photo_reset_button);
         photoResetButton.setOnClickListener(_v -> resetPhoto());
         photoButtonError = view.findViewById(R.id.photo_button_error);
+        visibilityToggle = view.findViewById(R.id.visibility_button);
 
         updateResetPhotoVisibility();
         addLocation = view.findViewById(R.id.add_location_button);

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodEventForm.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodEventForm.java
@@ -85,6 +85,7 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
         photoButton.setImageResource(R.drawable.upload_splash);
 
         updateResetPhotoVisibility();
+        resetPhotoButtonError(); // Clear any error if present
     }
 
     /**
@@ -108,6 +109,10 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
      */
     private void updateResetPhotoVisibility() {
         photoResetButton.setVisibility(photo == null ? INVISIBLE : VISIBLE);
+
+        ViewGroup.LayoutParams layoutParams = photoResetButton.getLayoutParams();
+        layoutParams.height = photo == null ? 0 : ViewGroup.LayoutParams.WRAP_CONTENT;
+        photoResetButton.setLayoutParams(layoutParams);
     }
 
     private MoodEventFormSubmitCallback callback;
@@ -192,8 +197,15 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
         }
         photo = details.photo;
         photoButton.setImageBitmap(details.photo);
-
         updateResetPhotoVisibility();
+
+    private void resetPhotoButtonError() {
+        photoButtonError.setText(null);
+
+        // Hide the photo button error element
+        ViewGroup.LayoutParams layoutParams = photoButtonError.getLayoutParams();
+        layoutParams.height = 0;
+        photoButtonError.setLayoutParams(layoutParams);
     }
 
     private @Nullable MoodEventDetails validateFields() {
@@ -201,7 +213,7 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
 
         emotionPickerFragment.setError(null);
         reasonEditText.setError(null);
-        photoButtonError.setText(null);
+        resetPhotoButtonError();
 
         details.emotion = emotionPickerFragment.getSelected();
         if (details.emotion == null) {
@@ -222,10 +234,15 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
         if (photo != null && PhotoUtils.compressPhoto(photo).size() > 65536) {
             Log.i("MoodEventForm", "Image too large");
             photoButtonError.setText("Image too large");
+
+            ViewGroup.LayoutParams layoutParams = photoButtonError.getLayoutParams();
+            layoutParams.height = ViewGroup.LayoutParams.WRAP_CONTENT;
+            photoButtonError.setLayoutParams(layoutParams);
             return null;
         }
         details.lat = currentLatitude;
         details.lon = currentLongitude;
+
         return details;
     }
 

--- a/code/app/src/main/res/layout/fragment_mood_event_form.xml
+++ b/code/app/src/main/res/layout/fragment_mood_event_form.xml
@@ -89,7 +89,7 @@
             android:id="@+id/photo_reset_button"
             style="@style/Widget.Material3.Button.TextButton"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
             android:layout_marginEnd="16dp"
@@ -101,7 +101,8 @@
         <TextView
             android:id="@+id/photo_button_error"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
+            android:layout_marginBottom="8dp"
             android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
             android:textColor="@color/design_default_color_error" />
 

--- a/code/app/src/main/res/layout/fragment_mood_event_form.xml
+++ b/code/app/src/main/res/layout/fragment_mood_event_form.xml
@@ -106,6 +106,32 @@
             android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
             android:textColor="@color/design_default_color_error" />
 
+        <com.google.android.material.button.MaterialButtonToggleGroup
+            android:id="@+id/visibility_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:checkedButton="@id/visible_public_button"
+            app:singleSelection="true">
+
+            <Button
+                android:id="@+id/visible_public_button"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                app:icon="@drawable/ic_person"
+                android:text="Public" />
+
+            <Button
+                android:id="@+id/visible_private_button"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                app:icon="@drawable/ic_lock"
+                android:text="Private" />
+        </com.google.android.material.button.MaterialButtonToggleGroup>
+
         <Button
             android:id="@+id/submit_button"
             android:layout_width="match_parent"


### PR DESCRIPTION
Resolves: #205

## Summary

- Fix spacing caused by empty photo button and photo error views
- Add mood event visibility to mood events data class
- Add mood event visibility toggle to mood event form
- Add tests

## Testing

- How should a reviewer test this feature, fix, or UI?
  - Create a new mood event and set visibility
  - Edit the mood event with a visibility set
  - Edit a mood event created before this change
- Are there any specific commands, steps, or credentials needed?
  - None.

## Merge Instructions

- Any considerations that other PR's may need to take into note? 
  - None.
- Should the reviewer delete the branch on merge? Y/N
  - Y

---

**Checklist**
- [x] Are all relevant issues referenced by this PR?
- [x] Does the app still build (locally)?
- [x] Do all tests pass?
- [x] Does the feature work as expected?
- [x] Does this feature preserve the app’s existing stability?  
- [x] Is the description of the changes correct/present?
- [x] Have new tests been created or existing tests updated as needed?

---

