### PR TITLE
Remove trigger, change reason validation in mood event form

### DIFF
--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/CreateMoodEventTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/CreateMoodEventTest.java
@@ -93,31 +93,16 @@ public class CreateMoodEventTest extends FirebaseEmulatorMixin {
         onView(withId(R.id.toggle_happy)).perform(click());
 
         onView(withId(R.id.emotion_reason))
-                .perform(scrollTo(), typeText("This is a really long string with too many characters"));
+                .perform(scrollTo(), typeText("This is a really long string with too many characters when will it end. I have to make this stretch until 200 characters which is absurdly long so the text field should be able to handle almost all messages -- except for this one! Just a few more characters to go"));
         Espresso.closeSoftKeyboard();
 
         onView(withId(R.id.submit_button)).perform(scrollTo()).perform(click());
         onView(withId(R.id.emotion_reason))
-                .check(matches(hasErrorText("Reason must be less than 20 characters or 3 words")));
+                .check(matches(hasErrorText("Reason must be less than 200 characters")));
     }
 
     @Test
-    public void createNewMoodReasonTooManyWords() {
-        onView(withId(R.id.page_createMoodEvent)).perform(click());
-
-        onView(withId(R.id.toggle_happy)).perform(click());
-
-        onView(withId(R.id.emotion_reason))
-                .perform(scrollTo(), typeText("AAAAAAAAAAA AAAAAAAAAAAAAAAA AAAAAAAAAAAAAA AAA"));
-        Espresso.closeSoftKeyboard();
-
-        onView(withId(R.id.submit_button)).perform(scrollTo()).perform(click());
-        onView(withId(R.id.emotion_reason))
-                .check(matches(hasErrorText("Reason must be less than 20 characters or 3 words")));
-    }
-
-    @Test
-    public void createNewMoodReasonJustEnoughWords() {
+    public void createNewMoodReasonNotTooLong() {
         FirebaseFirestore db = FirebaseFirestore.getInstance();
 
         onView(withId(R.id.page_createMoodEvent)).perform(click());
@@ -125,7 +110,7 @@ public class CreateMoodEventTest extends FirebaseEmulatorMixin {
         onView(withId(R.id.toggle_anger)).perform(click());
 
         onView(withId(R.id.emotion_reason))
-                .perform(scrollTo(), typeText("AAAAAAAAAAA AAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAA"));
+                .perform(scrollTo(), typeText("AAAAAAAAAAAAAAAAAAAAAAAAAAA"));
         Espresso.closeSoftKeyboard();
 
         onView(withId(R.id.submit_button)).perform(scrollTo()).perform(click());

--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/DeleteDialogFragmentUITests.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/DeleteDialogFragmentUITests.java
@@ -47,10 +47,8 @@ public class DeleteDialogFragmentUITests extends FirebaseEmulatorMixin {
         MoodEvent moodEvent = new MoodEvent(
                 auth.getCurrentUser().getUid(),
                 Emotion.HAPPINESS,
-                "Test Trigger",
                 "Test Social Situation",
                 "Test Reason",
-                "",
                 0.0,
                 0.0
         );
@@ -121,10 +119,8 @@ public class DeleteDialogFragmentUITests extends FirebaseEmulatorMixin {
             MoodEvent moodEvent = new MoodEvent(
                     auth.getCurrentUser().getUid(),
                     Emotion.ANGER,
-                    "Test Mood",
                     "Test Social Situation",
                     "Test Reason",
-                    "",
                     0.0,
                     0.0
             );

--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/EditMoodEventTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/EditMoodEventTest.java
@@ -48,8 +48,6 @@ public class EditMoodEventTest extends FirebaseEmulatorMixin {
                 Emotion.DISGUST,
                 "",
                 "",
-                "",
-                "",
                 0.0,
                 0.0
         );

--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/LocationInstrumentedTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/LocationInstrumentedTest.java
@@ -60,10 +60,8 @@ public class LocationInstrumentedTest extends FirebaseEmulatorMixin {
         MoodEvent moodEvent = new MoodEvent(
                 auth.getCurrentUser().getUid(),
                 Emotion.HAPPINESS,
-                "Test Trigger",
                 "Test Social Situation",
                 "Test Reason",
-                "",
                 null,
                 null
         );
@@ -124,14 +122,14 @@ public class LocationInstrumentedTest extends FirebaseEmulatorMixin {
         
         // Select an emotion
         onView(withId(R.id.toggle_happy)).perform(click());
-        
+
         // Scroll to the trigger field first to ensure it's visible
-        onView(withId(R.id.emotion_trigger)).perform(scrollTo());
-        
+        onView(withId(R.id.emotion_reason)).perform(scrollTo());
+
         // Add some text to the trigger field - separate actions for stability
-        onView(withId(R.id.emotion_trigger)).perform(replaceText("Location Test"));
-        onView(withId(R.id.emotion_trigger)).perform(closeSoftKeyboard());
-        
+        onView(withId(R.id.emotion_reason)).perform(replaceText("Location Test"));
+        onView(withId(R.id.emotion_reason)).perform(closeSoftKeyboard());
+
         // Wait to ensure keyboard is closed
         SystemClock.sleep(500);
         
@@ -153,7 +151,7 @@ public class LocationInstrumentedTest extends FirebaseEmulatorMixin {
                     // Find the mood event with our test trigger
                     boolean foundTestMood = false;
                     for (DocumentSnapshot doc : moodEvents) {
-                        if ("Location Test".equals(doc.getString("trigger"))) {
+                        if ("Location Test".equals(doc.getString("reason"))) {
                             foundTestMood = true;
                             
                             // Verify location is null or empty

--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/MoodDetailsNavigationTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/MoodDetailsNavigationTest.java
@@ -44,10 +44,8 @@ public class MoodDetailsNavigationTest extends FirebaseEmulatorMixin {
     private static final String USER_EMAIL = "test@kernelcrew.com";
     private static final String USER_PASSWORD = "Password@1234";
     private static final Emotion DATA_EMOTION = Emotion.HAPPINESS;
-    private static final String DATA_TRIGGER = "Morning Coffee";
     private static final String DATA_SOCIALSITUATION = "With Friends";
     private static final String DATA_REASON = "Celebration";
-    private static final String DATA_PHOTOURL = "https://example.com/photo.jpg";
     private static final double DATA_LATITUDE = 34.052235;
     private static final double DATA_LONGITUDE = -118.243683;
 
@@ -100,12 +98,10 @@ public class MoodDetailsNavigationTest extends FirebaseEmulatorMixin {
         MoodEvent testEvent = new MoodEvent(
                 uid,
                 DATA_EMOTION,
-                DATA_TRIGGER,       // trigger
-                DATA_SOCIALSITUATION, // socialSituation
-                DATA_REASON,        // reason
-                DATA_PHOTOURL,      // photoUrl
-                DATA_LATITUDE,      // latitude
-                DATA_LONGITUDE      // longitude
+                DATA_SOCIALSITUATION,
+                DATA_REASON,
+                DATA_LATITUDE,
+                DATA_LONGITUDE
         );
         Tasks.await(MoodEventProvider.getInstance().insertMoodEvent(testEvent));
 
@@ -157,8 +153,6 @@ public class MoodDetailsNavigationTest extends FirebaseEmulatorMixin {
                 .check(matches(isDisplayed()));
         onView(withId(R.id.tvMoodState))
                 .check(matches(withText(DATA_EMOTION.toString())));
-        onView(withId(R.id.tvTriggerValue))
-                .check(matches(withText(DATA_TRIGGER)));
         onView(withId(R.id.tvSocialSituationValue))
                 .check(matches(withText(DATA_SOCIALSITUATION)));
         onView(withId(R.id.tvReasonValue))

--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/OtherProfilePageNavigationTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/OtherProfilePageNavigationTest.java
@@ -40,10 +40,8 @@ public class OtherProfilePageNavigationTest extends FirebaseEmulatorMixin {
     private static final String USER_PASSWORD = "Password@1234";
     private static final String EXPECTED_USERNAME = "testUser";
     private static final Emotion DATA_EMOTION = Emotion.HAPPINESS;
-    private static final String DATA_TRIGGER = "Morning Coffee";
     private static final String DATA_SOCIALSITUATION = "With Friends";
     private static final String DATA_REASON = "Celebration";
-    private static final String DATA_PHOTOURL = "https://example.com/photo.jpg";
     private static final double DATA_LATITUDE = 34.052235;
     private static final double DATA_LONGITUDE = -118.243683;
 
@@ -103,12 +101,10 @@ public class OtherProfilePageNavigationTest extends FirebaseEmulatorMixin {
         MoodEvent testEvent = new MoodEvent(
                 uid,
                 DATA_EMOTION,
-                DATA_TRIGGER,         // trigger
-                DATA_SOCIALSITUATION,   // socialSituation
-                DATA_REASON,          // reason
-                DATA_PHOTOURL,        // photoUrl
-                DATA_LATITUDE,        // latitude
-                DATA_LONGITUDE        // longitude
+                DATA_SOCIALSITUATION,
+                DATA_REASON,
+                DATA_LATITUDE,
+                DATA_LONGITUDE
         );
         Tasks.await(MoodEventProvider.getInstance().insertMoodEvent(testEvent));
 

--- a/code/app/src/main/java/com/kernelcrew/moodapp/data/MoodEvent.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/data/MoodEvent.java
@@ -25,7 +25,6 @@ public class MoodEvent implements Serializable {
     private String uid;
     private Date created;
     private Emotion emotion;
-    private String trigger;
     private String socialSituation;
     private String reason;
     private Bitmap photo;
@@ -41,13 +40,12 @@ public class MoodEvent implements Serializable {
      * Constructor for a new MoodEvent with additional details.
      * Will assign this mood event a new random id.
      */
-    public MoodEvent(String uid, Emotion emotion, String trigger, String socialSituation,
-                     String reason, String _photoUrl, Double latitude, Double longitude) {
+    public MoodEvent(String uid, Emotion emotion, String socialSituation, String reason,
+                     Double latitude, Double longitude) {
         this.id = UUID.randomUUID().toString();
         this.uid = uid;
         this.created = new Date();
         this.emotion = emotion;
-        this.trigger = trigger;
         this.socialSituation = socialSituation;
         this.reason = reason;
         this.latitude = latitude;
@@ -85,13 +83,6 @@ public class MoodEvent implements Serializable {
             // Fallback: assign a default emotion if conversion fails
             this.emotion = Emotion.ERROR;
         }
-    }
-
-    public String getTrigger() {
-        return trigger;
-    }
-    public void setTrigger(String trigger) {
-        this.trigger = trigger;
     }
 
     public String getSocialSituation() {

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodDetails.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodDetails.java
@@ -72,7 +72,6 @@ public class MoodDetails extends Fragment implements DeleteDialogFragment.Delete
         toolbar = view.findViewById(R.id.moodDetailsToolbar);
         imageMoodIcon = view.findViewById(R.id.imageMoodIcon);
         tvMoodState = view.findViewById(R.id.tvMoodState);
-        tvTriggerValue = view.findViewById(R.id.tvTriggerValue);
         tvSocialSituationValue = view.findViewById(R.id.tvSocialSituationValue);
         tvReasonValue = view.findViewById(R.id.tvReasonValue);
         ivMoodPhoto = view.findViewById(R.id.ivMoodPhoto);
@@ -140,7 +139,6 @@ public class MoodDetails extends Fragment implements DeleteDialogFragment.Delete
      */
     private void bindMoodData(MoodEvent moodEvent) {
         tvMoodState.setText(moodEvent.getEmotion().toString());
-        tvTriggerValue.setText(moodEvent.getTrigger());
         tvSocialSituationValue.setText(moodEvent.getSocialSituation());
         tvReasonValue.setText(moodEvent.getReason());
 

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodEventForm.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodEventForm.java
@@ -205,8 +205,8 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
         details.socialSituation = situationAutoComplete.getText().toString();
 
         details.reason = reasonEditText.getText().toString();
-        if (details.reason.length() > 20 && details.reason.split(" ").length > 3) {
-            reasonEditText.setError("Reason must be less than 20 characters or 3 words");
+        if (details.reason.length() > 200) {
+            reasonEditText.setError("Reason must be less than 200 characters");
             return null;
         }
 

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodEventForm.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodEventForm.java
@@ -43,10 +43,8 @@ import java.io.IOException;
  * When editing a mood event, update the form state per a mood event using the .bind() method.
  */
 public class MoodEventForm extends Fragment implements LocationUpdateListener {
-    private EmotionPickerFragment emotionPickerFragment;
-    private TextInputEditText triggerEditText;
-
     private Button addLocation;
+    private EmotionPickerFragment emotionPickerFragment;
     private AutoCompleteTextView situationAutoComplete;
     private TextInputEditText reasonEditText;
     private Double currentLatitude = null;
@@ -129,7 +127,6 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
 
     public static class MoodEventDetails {
         Emotion emotion;
-        String trigger;
         String socialSituation;
         String reason;
         Double lat;
@@ -147,7 +144,6 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
          */
         public MoodEventDetails(MoodEvent moodEvent) {
             emotion = moodEvent.getEmotion();
-            trigger = moodEvent.getTrigger();
             socialSituation = moodEvent.getSocialSituation();
             reason = moodEvent.getReason();
             lat = moodEvent.getLatitude();
@@ -164,10 +160,8 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
             MoodEvent moodEvent = new MoodEvent(
                     uid,
                     emotion,
-                    trigger,
                     socialSituation,
                     reason,
-                    "", // photoUrl,
                     lat,
                     lon
             );
@@ -180,7 +174,6 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
 
     public void bind(MoodEventDetails details) {
         emotionPickerFragment.setSelected(details.emotion);
-        triggerEditText.setText(details.trigger);
         situationAutoComplete.setText(details.socialSituation);
         reasonEditText.setText(details.reason);
         if (details.lat != null && details.lon != null) {
@@ -209,7 +202,6 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
             return null;
         }
 
-        details.trigger = triggerEditText.getText().toString();
         details.socialSituation = situationAutoComplete.getText().toString();
 
         details.reason = reasonEditText.getText().toString();
@@ -263,7 +255,6 @@ public class MoodEventForm extends Fragment implements LocationUpdateListener {
             return;
         }
 
-        triggerEditText = view.findViewById(R.id.emotion_trigger);
         situationAutoComplete = view.findViewById(R.id.emotion_situation);
         reasonEditText = view.findViewById(R.id.emotion_reason);
         photoButton = view.findViewById(R.id.photo_button);

--- a/code/app/src/main/res/layout/fragment_mood_details.xml
+++ b/code/app/src/main/res/layout/fragment_mood_details.xml
@@ -110,30 +110,6 @@
                     android:orientation="vertical"
                     android:padding="16dp">
 
-                    <!-- Trigger Field -->
-                    <com.google.android.material.textfield.TextInputLayout
-                        android:id="@+id/tvTriggerLabel"
-                        style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:hint="Trigger"
-                        app:boxCornerRadiusTopStart="12dp"
-                        app:boxCornerRadiusTopEnd="12dp"
-                        app:boxCornerRadiusBottomStart="12dp"
-                        app:boxCornerRadiusBottomEnd="12dp"
-                        app:boxBackgroundColor="@color/light_gray"
-                        app:boxStrokeWidth="0dp"
-                        app:boxStrokeWidthFocused="2dp">
-
-                        <com.google.android.material.textfield.TextInputEditText
-                            android:id="@+id/tvTriggerValue"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="Some Trigger"
-                            android:enabled="false" />
-                    </com.google.android.material.textfield.TextInputLayout>
-
                     <!-- Social Situation Field -->
                     <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/tvSocialSituationLabel"

--- a/code/app/src/main/res/layout/fragment_mood_event_form.xml
+++ b/code/app/src/main/res/layout/fragment_mood_event_form.xml
@@ -29,18 +29,6 @@
             android:layout_marginTop="8dp" />
 
         <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/layout_trigger"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Trigger">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/emotion_trigger"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/layout_situation"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
             android:layout_width="match_parent"


### PR DESCRIPTION
Resolves: #197
Resolves: #199

## Summary

- Remove trigger, photoURL from mood event
- Change reason validation to <=200 chars

## Testing

- How should a reviewer test this feature, fix, or UI?
  - Create a new or edit a mood event
  - Notice the lack of trigger field
  - Try to create a mood event with a reason >200 chars and see the error
  - View a mood event and notice the lack of the trigger field
- Are there any specific commands, steps, or credentials needed?
  - None

## Merge Instructions

- Any considerations that other PR's may need to take into note? 
  - None
- Should the reviewer delete the branch on merge? Y/N
  - Y

---

**Checklist**
- [x] Are all relevant issues referenced by this PR?
- [x] Does the app still build (locally)?
- [x] Do all tests pass?
- [x] Does the feature work as expected?
- [x] Does this feature preserve the app’s existing stability?  
- [x] Is the description of the changes correct/present?
- [x] Have new tests been created or existing tests updated as needed?

---

