### PR TITLE
Hide private mood events from all other users

### DIFF
--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/FilterBarFragmentTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/FilterBarFragmentTest.java
@@ -15,6 +15,8 @@ import com.kernelcrew.moodapp.data.Emotion;
 import com.kernelcrew.moodapp.data.MoodEventFilter;
 import com.kernelcrew.moodapp.ui.components.FilterBarFragment;
 
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -22,9 +24,21 @@ import org.mockito.ArgumentCaptor;
 import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.concurrent.ExecutionException;
 
 @RunWith(AndroidJUnit4.class)
 public class FilterBarFragmentTest extends FirebaseEmulatorMixin {
+    @BeforeClass
+    public static void createNewUser() throws ExecutionException, InterruptedException {
+        staticCreateUser();
+    }
+
+    @Before
+    public void setupUser() throws ExecutionException, InterruptedException {
+        // MoodEventProvider requires an active user for public/private filtering
+        loginUser();
+    }
+
     public static class TestFilterBarFragmentFactory extends FragmentFactory {
         private final FilterBarFragment.OnFilterChangedListener listener;
         public TestFilterBarFragmentFactory(FilterBarFragment.OnFilterChangedListener listener) {

--- a/code/app/src/main/java/com/kernelcrew/moodapp/data/MoodEventFilter.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/data/MoodEventFilter.java
@@ -2,7 +2,6 @@ package com.kernelcrew.moodapp.data;
 
 import androidx.annotation.Nullable;
 
-import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.Query;
 import java.util.ArrayList;
 import java.util.Date;
@@ -13,7 +12,7 @@ import java.util.Set;
  * A class for filtering mood events in Firestore queries.
  */
 public class MoodEventFilter {
-    private final CollectionReference collectionReference;
+    private final Query allMoodEvents;
     private final Set<Emotion> emotions = new HashSet<>();
     private String userId;
     private Date startDate;
@@ -28,10 +27,10 @@ public class MoodEventFilter {
      * Constructor accepting a CollectionReference directly.
      * This is useful if you have the Firestore collection from your provider.
      *
-     * @param collectionReference The Firestore collection reference for mood events.
+     * @param allMoodEvents All mood events query
      */
-    public MoodEventFilter(CollectionReference collectionReference) {
-        this.collectionReference = collectionReference;
+    public MoodEventFilter(Query allMoodEvents) {
+        this.allMoodEvents = allMoodEvents;
     }
 
     /**
@@ -41,7 +40,7 @@ public class MoodEventFilter {
      * @param provider The MoodEventProvider instance to get the collection reference.
      */
     public MoodEventFilter(MoodEventProvider provider) {
-        this.collectionReference = provider.getCollectionReference();
+        this.allMoodEvents = provider.getAll();
     }
 
     /**
@@ -216,7 +215,7 @@ public class MoodEventFilter {
      */
     public Query buildQuery() {
         // Start with the collection reference
-        Query query = collectionReference;
+        Query query = allMoodEvents;
 
         if (userId != null) {
             query = query.whereEqualTo("uid", userId);

--- a/code/app/src/main/java/com/kernelcrew/moodapp/data/MoodEventProvider.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/data/MoodEventProvider.java
@@ -1,7 +1,5 @@
 package com.kernelcrew.moodapp.data;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
 import com.google.android.gms.tasks.Task;
@@ -9,10 +7,9 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.CollectionReference;
-import com.google.firebase.firestore.EventListener;
+import com.google.firebase.firestore.Filter;
 import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.ListenerRegistration;
-import com.google.firebase.firestore.QuerySnapshot;
+import com.google.firebase.firestore.Query;
 
 public class MoodEventProvider {
     private final CollectionReference collection;
@@ -37,10 +34,6 @@ public class MoodEventProvider {
         }
 
         return instance;
-    }
-
-    public static void setInstance(MoodEventProvider mockMoodEventProvider) {
-
     }
 
     /**
@@ -99,48 +92,15 @@ public class MoodEventProvider {
     }
 
     /**
-     * Add a snapshot listener to the mood events collection
-     * @param listener Snapshot listener to add
-     */
-    public void addSnapshotListener(@NonNull EventListener<QuerySnapshot> listener) {
-        collection.addSnapshotListener(listener);
-    }
-
-    /**
-     * Get a collection of mood events from the DB.
-     * @return A collection of mood events
-     */
-    public Task<QuerySnapshot> getMoodEvents(){
-        return collection.get();
-    }
-
-    /**
-     * Returns the Firestore CollectionReference for filtering purposes.
-     * This reference can be then in filtering to build queries or perform Firestore operations,
-     * like adding snapshot listeners or inserting and updating documents.
+     * Returns all mood events which can then be further filtered.
      *
-     * @return the CollectionReference instance for the mood events.
+     * @return All (visible) mood events.
      */
-    public CollectionReference getCollectionReference() {
-        return collection;
-    }
-
-    /**
-     * Add a snapshot listener to the mood events collection, filtered by the current user's UID.
-     * This method returns a ListenerRegistration that can be used to remove the listener.
-     *
-     * @param listener Snapshot listener to add
-     * @return ListenerRegistration that can be used to remove the listener
-     */
-    public ListenerRegistration addUserFilteredSnapshotListener(@NonNull EventListener<QuerySnapshot> listener) {
+    public Query getAll() {
         FirebaseUser user = auth.getCurrentUser();
-        if (user != null) {
-            // Only listen for mood events belonging to the current user
-            return collection.whereEqualTo("uid", user.getUid())
-                    .addSnapshotListener(listener);
-        } else {
-            // If no user is logged in, listen to an empty query
-            return collection.limit(0).addSnapshotListener(listener);
-        }
+        return collection.where(Filter.or(
+                Filter.and(Filter.equalTo("uid", user.getUid()),
+                           Filter.equalTo("visibility", "PRIVATE")),
+                Filter.equalTo("visibility", "PUBLIC")));
     }
 }

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodAdapter.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodAdapter.java
@@ -83,6 +83,15 @@ public class MoodAdapter extends RecyclerView.Adapter<MoodAdapter.MoodViewHolder
                 onMoodClickListener.onViewComments(mood);
             }
         });
+
+        switch (mood.getVisibility()) {
+            case PUBLIC:
+                holder.visibilityIcon.setImageResource(R.drawable.ic_public);
+                break;
+            case PRIVATE:
+                holder.visibilityIcon.setImageResource(R.drawable.ic_lock);
+                break;
+        }
     }
 
     @Override
@@ -101,6 +110,8 @@ public class MoodAdapter extends RecyclerView.Adapter<MoodAdapter.MoodViewHolder
         ImageView comments_bubble;
         View commentLayout;
 
+        ImageView visibilityIcon;
+
         public MoodViewHolder(@NonNull View itemView) {
             super(itemView);
             moodImageView = itemView.findViewById(R.id.moodImage); // initialize new view
@@ -111,6 +122,7 @@ public class MoodAdapter extends RecyclerView.Adapter<MoodAdapter.MoodViewHolder
             purple_icon_arrow = itemView.findViewById(R.id.purpleIconArrow);
             comments_bubble = itemView.findViewById(R.id.comments_bubble);
             commentLayout = itemView.findViewById(R.id.commentLayout);
+            visibilityIcon = itemView.findViewById(R.id.visibility_icon);
         }
     }
 }

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodDetails.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/MoodDetails.java
@@ -35,8 +35,8 @@ public class MoodDetails extends Fragment implements DeleteDialogFragment.Delete
     private Chip tvUsernameDisplay;
     private Button btnEditMood;
     private Button btnDeleteMood;
-
     private Button btnMoodComments;
+    private ImageView visibilityIcon;
 
     private FirebaseFirestore db;
     private MoodEventProvider provider;
@@ -83,6 +83,7 @@ public class MoodDetails extends Fragment implements DeleteDialogFragment.Delete
         btnEditMood = view.findViewById(R.id.btnEditMood);
         btnDeleteMood = view.findViewById(R.id.btnDeleteMood);
         btnMoodComments = view.findViewById(R.id.btnMoodComments);
+        visibilityIcon = view.findViewById(R.id.visibility_icon);
 
         toolbar.setNavigationOnClickListener(v -> handleBackButton());
 
@@ -144,6 +145,15 @@ public class MoodDetails extends Fragment implements DeleteDialogFragment.Delete
         Bitmap photo = moodEvent.getPhoto();
         if (photo != null) {
             ivMoodPhoto.setImageBitmap(photo);
+        }
+
+        switch (moodEvent.getVisibility()) {
+            case PUBLIC:
+                visibilityIcon.setImageResource(R.drawable.ic_public);
+                break;
+            case PRIVATE:
+                visibilityIcon.setImageResource(R.drawable.ic_lock);
+                break;
         }
 
         // Fetch username via UserProvider

--- a/code/app/src/main/res/drawable/ic_public.xml
+++ b/code/app/src/main/res/drawable/ic_public.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM11,19.93c-3.95,-0.49 -7,-3.85 -7,-7.93 0,-0.62 0.08,-1.21 0.21,-1.79L9,15v1c0,1.1 0.9,2 2,2v1.93zM17.9,17.39c-0.26,-0.81 -1,-1.39 -1.9,-1.39h-1v-3c0,-0.55 -0.45,-1 -1,-1L8,12v-2h2c0.55,0 1,-0.45 1,-1L11,7h2c1.1,0 2,-0.9 2,-2v-0.41c2.93,1.19 5,4.06 5,7.41 0,2.08 -0.8,3.97 -2.1,5.39z"/>
+    
+</vector>

--- a/code/app/src/main/res/layout/fragment_mood_details.xml
+++ b/code/app/src/main/res/layout/fragment_mood_details.xml
@@ -58,6 +58,12 @@
                     android:textAppearance="?attr/textAppearanceHeadline6"
                     android:textColor="@android:color/black" />
 
+                <ImageView
+                    android:id="@+id/visibility_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_lock" />
+
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/btnEditMood"
                     android:visibility="gone"

--- a/code/app/src/main/res/layout/item_mood.xml
+++ b/code/app/src/main/res/layout/item_mood.xml
@@ -95,13 +95,27 @@
                 android:layout_marginStart="16dp"
                 android:orientation="vertical">
 
-                <TextView
-                    android:id="@+id/moodTypeText"
-                    android:layout_width="wrap_content"
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Confused"
-                    android:textStyle="bold"
-                    android:textSize="16sp" />
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/moodTypeText"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Confused"
+                        android:textSize="16sp"
+                        android:textStyle="bold" />
+
+                    <ImageView
+                        android:id="@+id/visibility_icon"
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        android:layout_marginLeft="4dp"
+                        android:src="@drawable/ic_public" />
+                </LinearLayout>
 
                 <TextView
                     android:id="@+id/dayTimeText"


### PR DESCRIPTION
Resolves: #206

## Summary

- Hide private mood events from users other than their owners
- Draw the mood event visibility on the mood item card (on home screen)
- Add visibility icon to the mood details page

## Testing

- How should a reviewer test this feature, fix, or UI?
     - Create a public mood event as user A. Confirm that users A and B can view that event.
     - Create a private mood event as user A. Confirm that user A can view and B cannot view that event.
- Are there any specific commands, steps, or credentials needed?
     - No

## Merge Instructions

- Any considerations that other PR's may need to take into note? 
     - No
- Should the reviewer delete the branch on merge? 
     - Yes

---

**Checklist**
- [ ] Are all relevant issues referenced by this PR?
- [ ] Does the app still build (locally)?
- [ ] Do all tests pass?
- [ ] Does the feature work as expected?
- [ ] Does this feature preserve the app’s existing stability?  
- [ ] Is the description of the changes correct/present?
- [ ] Have new tests been created or existing tests updated as needed?

---

