### PR TITLE
Fix generate JavaDocs failures when merging to `main`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,10 +19,11 @@ jobs:
         with:
           java-version: '17'
 
-      - name: Inflate google-services.json
-        run: scripts/ci.sh inflate-ci-googleservices
+      - name: Inflate CI Secrets
+        run: scripts/ci.sh inflate-ci-secrets
         env:
           ACTIONS_GOOGLESERVICES: ${{ secrets.ACTIONS_GOOGLESERVICES }}
+          ACTIONS_MAPSAPIKEY: ${{ secrets.ACTIONS_MAPSAPIKEY }}
 
       - name: Generate JavaDocs
         run: scripts/ci.sh generate-javadocs


### PR DESCRIPTION
## Summary

Should fix the "Generate JavaDocs" CI job failure after merging to main.

## Testing

- How should a reviewer test this feature, fix, or UI?
     - No testing required.
- Are there any specific commands, steps, or credentials needed?
     - None required.

## Merge Instructions

- Any considerations that other PR's may need to take into note? 
     - No
- Should the reviewer delete the branch on merge? 
     - Yes

---

**Checklist**
- [x] Are all relevant issues referenced by this PR?
- [x] Does the app still build (locally)?
- [x] Do all tests pass?
- [x] Does the feature work as expected?
- [x] Does this feature preserve the app’s existing stability?  
- [x] Is the description of the changes correct/present?
- [x] Have new tests been created or existing tests updated as needed?

---

