### PR TITLE
Limit mood events shown on other user profile page

### DIFF
--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/OtherUserProfileMoodTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/OtherUserProfileMoodTest.java
@@ -110,8 +110,8 @@ public class OtherUserProfileMoodTest extends FirebaseEmulatorMixin {
 
         // Seed several public MoodEvent documents for USER2.
         MoodEventProvider moodEventProvider = MoodEventProvider.getInstance();
-        // Create three distinct mood events.
-        for (int i = 1; i <= 3; i++) {
+        // Create many distinct mood events.
+        for (int i = 1; i <= 5; i++) {
             MoodEvent mood = new MoodEvent(
                     uid2,
                     USER2_USERNAME,
@@ -154,7 +154,7 @@ public class OtherUserProfileMoodTest extends FirebaseEmulatorMixin {
     }
 
     @Test
-    public void testOtherUserProfileDisplaysCorrectMoods() throws InterruptedException {
+    public void testOtherUserProfileDisplaysCorrectMoods() {
         // Ensure HomeFeed's RecyclerView is displayed.
         onView(withId(R.id.moodRecyclerView)).check(matches(isDisplayed()));
 
@@ -178,14 +178,14 @@ public class OtherUserProfileMoodTest extends FirebaseEmulatorMixin {
         onView(withId(R.id.email_text))
                 .check(matches(withText(USER2_EMAIL)));
 
-        // Check that the RecyclerView for public moods displays at least 2 items.
+        // Check that the RecyclerView for public moods displays no more than 3 items.
         onView(withId(R.id.public_moods_recycler_view))
                 .check((view, noViewFoundException) -> {
                     assertNotNull("RecyclerView is null", view);
                     RecyclerView recyclerView = (RecyclerView) view;
                     int itemCount = recyclerView.getAdapter().getItemCount();
-                    if (itemCount < 2) {
-                        throw new AssertionError("Expected at least 2 mood items, found " + itemCount);
+                    if (itemCount > 3) {
+                        throw new AssertionError("Expected at no more than 3 mood items, found " + itemCount);
                     }
                 });
 

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/OtherUserProfile.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/OtherUserProfile.java
@@ -25,6 +25,7 @@ import com.google.firebase.firestore.Query;
 import com.kernelcrew.moodapp.R;
 import com.kernelcrew.moodapp.data.FollowProvider;
 import com.kernelcrew.moodapp.data.MoodEvent;
+import com.kernelcrew.moodapp.data.MoodEventProvider;
 import com.kernelcrew.moodapp.data.UserProvider;
 import com.kernelcrew.moodapp.utils.NotificationHelper;
 
@@ -180,11 +181,11 @@ public class OtherUserProfile extends Fragment {
         publicMoodsRecyclerView.setAdapter(moodAdapter);
 
         if (uidToLoad != null) {
-            Query query = FirebaseFirestore.getInstance()
-                    .collection("moodEvents")
+            Query query = MoodEventProvider.getInstance()
+                    .getAll()
                     .whereEqualTo("uid", uidToLoad)
-                    .whereEqualTo("visibility", "PUBLIC")
-                    .orderBy("created", Query.Direction.DESCENDING);
+                    .orderBy("created", Query.Direction.DESCENDING)
+                    .limit(3);
 
             query.addSnapshotListener((snapshots, error) -> {
                 if (error != null) {


### PR DESCRIPTION
## Summary

A brief summary of features implemented

Resolves: #281

## Testing

- How should a reviewer test this feature, fix, or UI?
     - Try viewing a user who has >3 mood events. Their other user profile page shouldn't show more than 3
- Are there any specific commands, steps, or credentials needed?
     - No

## Merge Instructions

- Any considerations that other PR's may need to take into note? 
     - No
- Should the reviewer delete the branch on merge? 
     - Yes

---

**Checklist**
- [ ] Are all relevant issues referenced by this PR?
- [ ] Does the app still build (locally)?
- [ ] Do all tests pass?
- [ ] Does the feature work as expected?
- [ ] Does this feature preserve the app’s existing stability?  
- [ ] Is the description of the changes correct/present?
- [ ] Have new tests been created or existing tests updated as needed?

---

