### PR TITLE
Revert "Limit mood events shown on other user profile page"

### DIFF
--- a/code/app/src/androidTest/java/com/kernelcrew/moodapp/OtherUserProfileMoodTest.java
+++ b/code/app/src/androidTest/java/com/kernelcrew/moodapp/OtherUserProfileMoodTest.java
@@ -110,8 +110,8 @@ public class OtherUserProfileMoodTest extends FirebaseEmulatorMixin {
 
         // Seed several public MoodEvent documents for USER2.
         MoodEventProvider moodEventProvider = MoodEventProvider.getInstance();
-        // Create many distinct mood events.
-        for (int i = 1; i <= 5; i++) {
+        // Create three distinct mood events.
+        for (int i = 1; i <= 3; i++) {
             MoodEvent mood = new MoodEvent(
                     uid2,
                     USER2_USERNAME,
@@ -154,7 +154,7 @@ public class OtherUserProfileMoodTest extends FirebaseEmulatorMixin {
     }
 
     @Test
-    public void testOtherUserProfileDisplaysCorrectMoods() {
+    public void testOtherUserProfileDisplaysCorrectMoods() throws InterruptedException {
         // Ensure HomeFeed's RecyclerView is displayed.
         onView(withId(R.id.moodRecyclerView)).check(matches(isDisplayed()));
 
@@ -178,14 +178,14 @@ public class OtherUserProfileMoodTest extends FirebaseEmulatorMixin {
         onView(withId(R.id.email_text))
                 .check(matches(withText(USER2_EMAIL)));
 
-        // Check that the RecyclerView for public moods displays no more than 3 items.
+        // Check that the RecyclerView for public moods displays at least 2 items.
         onView(withId(R.id.public_moods_recycler_view))
                 .check((view, noViewFoundException) -> {
                     assertNotNull("RecyclerView is null", view);
                     RecyclerView recyclerView = (RecyclerView) view;
                     int itemCount = recyclerView.getAdapter().getItemCount();
-                    if (itemCount > 3) {
-                        throw new AssertionError("Expected at no more than 3 mood items, found " + itemCount);
+                    if (itemCount < 2) {
+                        throw new AssertionError("Expected at least 2 mood items, found " + itemCount);
                     }
                 });
 

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/OtherUserProfile.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/OtherUserProfile.java
@@ -25,7 +25,6 @@ import com.google.firebase.firestore.Query;
 import com.kernelcrew.moodapp.R;
 import com.kernelcrew.moodapp.data.FollowProvider;
 import com.kernelcrew.moodapp.data.MoodEvent;
-import com.kernelcrew.moodapp.data.MoodEventProvider;
 import com.kernelcrew.moodapp.data.UserProvider;
 import com.kernelcrew.moodapp.utils.NotificationHelper;
 
@@ -181,11 +180,11 @@ public class OtherUserProfile extends Fragment {
         publicMoodsRecyclerView.setAdapter(moodAdapter);
 
         if (uidToLoad != null) {
-            Query query = MoodEventProvider.getInstance()
-                    .getAll()
+            Query query = FirebaseFirestore.getInstance()
+                    .collection("moodEvents")
                     .whereEqualTo("uid", uidToLoad)
-                    .orderBy("created", Query.Direction.DESCENDING)
-                    .limit(3);
+                    .whereEqualTo("visibility", "PUBLIC")
+                    .orderBy("created", Query.Direction.DESCENDING);
 
             query.addSnapshotListener((snapshots, error) -> {
                 if (error != null) {


### PR DESCRIPTION
Reverts cmput301-w25/project-kernelcrew#287

<img width="822" alt="image" src="https://github.com/user-attachments/assets/fe7c178e-27ca-475c-96fc-15b34874d317" />

Its only on the home feed that we are supposed to see only top 3 events of the users i am following
@PossiblyAShrub @adityadipakpatel confirm pls