### PR TITLE
Fix location-related crashes

### DIFF
--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/HomeFeed.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/HomeFeed.java
@@ -181,7 +181,10 @@ public class HomeFeed extends DefaultFilterBarFragment
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        this.registration.remove();
+
+        if (this.registration != null) {
+            this.registration.remove();
+        }
     }
 
     /**

--- a/code/app/src/main/java/com/kernelcrew/moodapp/ui/LocationFragment.java
+++ b/code/app/src/main/java/com/kernelcrew/moodapp/ui/LocationFragment.java
@@ -192,14 +192,16 @@ public class LocationFragment extends Fragment {
     }
 
     /**
-     * Called when the fragment is attached to an activity.
-     * Initializes the permission request launcher.
+     * Called after this view has been created.
+     * Initializes the permission request launcher. We do this here since the map should be
+     * initialized first.
      *
-     * @param context The context the fragment is attached to
+     * @param view The view that was created
+     * @param savedInstanceState State bundle provided by the fragment manager
      */
     @Override
-    public void onAttach(@NonNull Context context) {
-        super.onAttach(context);
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
 
         // Code from Anthropic, Claude 3.7 Sonnet, "Update to use modern Activity Result API", accessed 05-13-2024
         // Initialize the permission request launcher


### PR DESCRIPTION

## Summary

When moving between pages (especially with maps) too quickly, it is possible to
cause crashes when the page uninits before it fully inits (or inits in the
wrong order due to races.)

- **Get the location when the view has been created and thus the map should be attached**
- **Fix crash when removing registration before it has been added due to quick navigation**

## Testing

- How should a reviewer test this feature, fix, or UI?
     - Click around lots and check CI
- Are there any specific commands, steps, or credentials needed?
     - No

## Merge Instructions

- Any considerations that other PR's may need to take into note?
     - No
- Should the reviewer delete the branch on merge? 
     - Yes

---

**Checklist**
- [x] Are all relevant issues referenced by this PR?
- [x] Does the app still build (locally)?
- [x] Do all tests pass?
- [x] Does the feature work as expected?
- [x] Does this feature preserve the app’s existing stability?  
- [x] Is the description of the changes correct/present?
- [x] Have new tests been created or existing tests updated as needed?

---

